### PR TITLE
[CORE-490] Update docs to specify requirements for next network reset.

### DIFF
--- a/pages/validators/starting_the_network.md
+++ b/pages/validators/starting_the_network.md
@@ -80,7 +80,22 @@ Please make sure that grpc is enabled in `$HOME_TESTNET_2/config/app.toml`:
 enable = true
 ```
 
-In addition, non-standard gRPC ports are not supported at this time. Please run on port 9090.
+In addition, non-standard gRPC ports are not supported at this time. Please run on port 9090, which is the default
+port specified in the config file:
+
+```
+[grpc]
+
+...
+
+# Address defines the gRPC server address to bind to.
+address = "0.0.0.0:9090"
+```
+
+**Note** that grpc can be also be configured via start flags. Be careful not to change the default settings with either
+of the following flags: `--grpc.enable`, `--grpc.address`.
+
+
 
 ## Starting the Node
 


### PR DESCRIPTION
- grpc must be enabled
- until we fix the duplicate grpc address flag for the daemons, I added the additional requirement of just using the standard port for simplicity.

I updated [this linear task](https://linear.app/dydx/issue/CORE-489/consolidate-flags-for-grpcaddress) to remove the port requirement after the flags are fixed.