### PR TITLE
Update indexer_client.mdx

### DIFF
--- a/pages/integration_docs/indexer_client.mdx
+++ b/pages/integration_docs/indexer_client.mdx
@@ -418,28 +418,6 @@ transfers = transfers_response.data['transfers']
 **Params and Response**: See *<a id="getTransfers" href="/integration_docs/indexer_api#gettransfers">Indexer API</a>*
 
 
-### Get Funding Payments
-
-<Tabs items={["TypeScript", "Python"]}>
-<Tab>
-```typescript copy
-// address is the wallet address on dYdX chain, subaccountNumber is the subaccount number
-const response = await client.account.getSubaccountFunding(address, subaccountNumber);
-const fundingPayments = response.fundingPayments;
-```
-</Tab>
-<Tab>
-```python copy
-# address is the wallet address on dYdX chain, subaccount_number is the subaccount number
-funding_response = client.account.get_subaccount_funding(address, subaccount_number)
-funding = funding_response.data['fundingPayments']
-```
-</Tab>
-</Tabs>
-
-**Params and Response**: See *<a id="getFills" href="/integration_docs/indexer_api">Indexer API</a>*
-
-
 ### Get Historical PNL
 
 <Tabs items={["TypeScript", "Python"]}>


### PR DESCRIPTION
Removing get funding payments because the wrapper function calls an indexer API that doesn't exist. Users will have to get returned netFunding from get Perpetual Positions.