### PR TITLE
Add instructions to sign your commits

### DIFF
--- a/pages/developers/open_source_repositories.md
+++ b/pages/developers/open_source_repositories.md
@@ -6,3 +6,7 @@ Please find the open source repositories on our [GitHub](https://github.com/dydx
 * [Frontend](https://github.com/dydxprotocol/v4-web)
 * [Indexer](https://github.com/dydxprotocol/v4-chain/indexer)
 * [Terraform](https://github.com/dydxprotocol/v4-infrastructure)
+
+When contributing, please ensure your commits are verified. You can follow these steps to do so:
+* [Generate a new signing key](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key) for work use and [turn on Vigilant Mode](https://docs.github.com/en/authentication/managing-commit-signature-verification/displaying-verification-statuses-for-all-of-your-commits)
+* [Tell Git about your GPG key](https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key) and install `pinentry` if necessary


### PR DESCRIPTION
Interim solution - follow-up solution is to have a github actions workflow auto-comment if your commits are not signed