### PR TITLE
Fix other limits page

### DIFF
--- a/pages/trading/other_limits.md
+++ b/pages/trading/other_limits.md
@@ -1,6 +1,6 @@
 ## Other Limits
 
-Accounts may have a limited number of open orders for a given market/side pair at any one time determined by the net collateral of the account as per:
+Subaccounts may have a limited number of open orders at any one time determined by the net collateral of the subaccount as per:
 
 | Net Collateral | Short-term orders | Long-term or Conditional orders |
 | -------------- | ----------------- | ------------------------------- |
@@ -9,8 +9,8 @@ Accounts may have a limited number of open orders for a given market/side pair a
 | >= $100 and < $1,000       | 5                 | 5                               |
 | >= $1,000 and < $10,000      | 10                | 10                              |
 | >= $10,000 and < $100,000     | 100               | 100                             |
-| >= $100,000      | 200               | 200                             |
+| >= $100,000      | 1000               | 200                             |
 
-For example up to 10 open `BTC-USD` bids for an account with a net collateral of $2,000.
+For example up to 10 open bids across all markets for a subaccount with a net collateral of $2,000.
 
 Note that short-term `Immediate-or-Cancel` and `Fill-or-Kill` orders are always allowed.


### PR DESCRIPTION
open order limits are not per market. updated to reflect new 1000 limit for the highest tier too.