### PR TITLE
Refer to indexer endpoint section in networks in indexer API docs.

### DIFF
--- a/pages/developers/indexer/indexer_api.mdx
+++ b/pages/developers/indexer/indexer_api.mdx
@@ -5,7 +5,7 @@
 
 Base URLs:
 
-* <a href="https://indexer.v4testnet.dydx.exchange/v4">https://indexer.v4testnet.dydx.exchange/v4</a>
+See the [Indexer API](../networks/network1/resources.md#indexer-endpoints) section for the base URL of the indexer
 
 # Authentication
 

--- a/pages/networks/network1/resources.md
+++ b/pages/networks/network1/resources.md
@@ -12,8 +12,8 @@
 
 ## Indexer endpoints
 
-* API: https://indexer.v4testnet.dydx.exchange/v4
-* WS: wss://indexer.v4testnet.dydx.exchange/v4/ws
+* API: https://dydx-testnet.imperator.co/v4
+* WS: wss://dydx-testnet.imperator.co/v4/ws
 
 ## Snapshot Service
 

--- a/pages/networks/network1/resources.md
+++ b/pages/networks/network1/resources.md
@@ -10,6 +10,11 @@
 * StakingCabin: `182ab0015fb4b7d751b12a9c0162ac123445eac1@seed.dydx-testnet.stakingcabin.com:26656`
 * StakerSpace: `76b472b107ccf20c3d6c110c4a2a217306d2dedb@dydx-seed.staker.space:26656`
 
+## Indexer endpoints
+
+* API: https://indexer.v4testnet.dydx.exchange/v4
+* WS: wss://indexer.v4testnet.dydx.exchange/v4/ws
+
 ## Snapshot Service
 
 https://bwarelabs.com/snapshots


### PR DESCRIPTION
It's not perfect as all the examples still point to the testnet URL.