### PR TITLE
fix indexer endpoints local references

### DIFF
--- a/pages/developers/indexer/indexer_api.mdx
+++ b/pages/developers/indexer/indexer_api.mdx
@@ -3,9 +3,7 @@
 
 > Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
 
-Base URLs:
-
-See the [Indexer API](../networks/network1/resources.md#indexer-endpoints) section for the base URL of the indexer
+See the [Indexer API](../../networks/network1/resources.md#indexer-endpoints) section for the base URL of the indexer
 
 # Authentication
 

--- a/pages/developers/indexer/indexer_websocket.md
+++ b/pages/developers/indexer/indexer_websocket.md
@@ -2,7 +2,7 @@
 
 dYdX offers a WebSocket API for streaming v4 updates.
 
-You can connect to the v4 Testnet's webSockets at: `wss://indexer.v4testnet2.dydx.exchange/v4/ws`
+See the [Indexer API](../../networks/network1/resources.md#indexer-endpoints) section for the base URL of the indexer
 
 ## Overall
 


### PR DESCRIPTION
- the correct path to the resources needs start with two levels up: `../../`
- the websockets endpoint can also be linked as a local reference  