### PR TITLE
Fix indexer client to indexer api links.

### DIFF
--- a/pages/developers/clients/indexer_client.mdx
+++ b/pages/developers/clients/indexer_client.mdx
@@ -100,7 +100,7 @@ markets_response = client.markets.get_perpetual_markets()
 </Tabs>
 
 
-**Params and Response**: See *<a id="listPerpetualMarkets" href="/integration_docs/indexer_api#listperpetualmarkets">Indexer API</a>*
+**Params and Response**: See *<a id="listPerpetualMarkets" href="/developers/indexer/indexer_api#listperpetualmarkets">Indexer API</a>*
 
 
 
@@ -120,10 +120,10 @@ sparklines_response = client.markets.get_perpetual_markets_sparklines()
 </Tabs>
 
 
-**Params and Response**: See *<a id="listPerpetualMarkets" href="/integration_docs/indexer_api#listperpetualmarkets">Indexer API</a>*
+**Params and Response**: See *<a id="listPerpetualMarkets" href="/developers/indexer/indexer_api#get">Indexer API</a>*
 
 
-### Get Perpetual Markets
+### Get Perpetual Market
 
 <Tabs items={["TypeScript", "Python"]}>
 <Tab>
@@ -141,7 +141,7 @@ markets_response = client.markets.get_perpetual_markets(ticker)
 </Tabs>
 
 
-**Params and Response**: See *<a id="getPerpetualMarket" href="/integration_docs/indexer_api#listperpetualmarkets">Indexer API</a>*
+**Params and Response**: See *<a id="getPerpetualMarket" href="/developers/indexer/indexer_api#listperpetualmarkets">Indexer API</a>*
 
 
 ### Get Orderbook
@@ -167,7 +167,7 @@ market_orderbook_bids = btc_market_orderbook['bids']
 </Tabs>
 
 
-**Params and Response**: See *<a id="getPerpetualMarketOrderbook" href="/integration_docs/indexer_api">Indexer API</a>*
+**Params and Response**: See *<a id="getPerpetualMarketOrderbook" href="/developers/indexer/indexer_api#getperpetualmarket">Indexer API</a>*
 
 
 ### Get Trades
@@ -190,7 +190,7 @@ market_trades = btc_market_trades_response.data['trades']
 </Tabs>
 
 
-**Params and Response**: See *<a id="getPerpetualMarketTrades" href="/integration_docs/indexer_api#gettrades">Indexer API</a>*
+**Params and Response**: See *<a id="getPerpetualMarketTrades" href="/developers/indexer/indexer_api#gettrades">Indexer API</a>*
 
 
 ### Get Historical Funding
@@ -213,7 +213,7 @@ market_funding = market_funding_response.data['historicalFunding']
 </Tabs>
 
 
-**Params and Response**: See *<a id="getPerpetualMarketFunding" href="/integration_docs/indexer_api#gethistoricalfunding">Indexer API</a>*
+**Params and Response**: See *<a id="getPerpetualMarketFunding" href="/developers/indexer/indexer_api#gethistoricalfunding">Indexer API</a>*
 
 
 
@@ -237,7 +237,7 @@ market_candles = market_candles_response.data['candles']
 </Tabs>
 
 
-**Params and Response**: See *<a id="getPerpetualMarketCandles" href="/integration_docs/indexer_api#getcandles">Indexer API</a>*
+**Params and Response**: See *<a id="getPerpetualMarketCandles" href="/developers/indexer/indexer_api#getcandles">Indexer API</a>*
 
 ## Subaccount
 
@@ -260,7 +260,7 @@ subaccounts = subaccounts_response.data['subaccounts']
 </Tab>
 </Tabs>
 
-**Params and Response**: See *<a id="listSubaccounts" href="/integration_docs/indexer_api#getaddress">Indexer API</a>*
+**Params and Response**: See *<a id="listSubaccounts" href="/developers/indexer/indexer_api#getaddress">Indexer API</a>*
 
 
 ### Get Subaccount
@@ -282,10 +282,10 @@ subaccount = subaccount_response.data['subaccount']
 </Tab>
 </Tabs>
 
-**Params and Response**: See *<a id="getSubaccount" href="/integration_docs/indexer_api#getsubaccount">Indexer API</a>*
+**Params and Response**: See *<a id="getSubaccount" href="/developers/indexer/indexer_api#getsubaccount">Indexer API</a>*
 
 
-### Get Assets
+### Get Asset Positions
 
 <Tabs items={["TypeScript", "Python"]}>
 <Tab>
@@ -304,7 +304,7 @@ asset_positions = asset_positions_response.data['positions']
 </Tab>
 </Tabs>
 
-**Params and Response**: See *<a id="getAssets" href="/integration_docs/indexer_api#getsubaccount">Indexer API</a>*
+**Params and Response**: See *<a id="getAssets" href="/developers/indexer/indexer_api#getassetpositions">Indexer API</a>*
 
 
 ### Get Perpetual Positions
@@ -326,7 +326,7 @@ perpetual_positions = perpetual_positions_response.data['positions']
 </Tab>
 </Tabs>
 
-**Params and Response**: See *<a id="getPerpetualPositions" href="/integration_docs/indexer_api#listpositions">Indexer API</a>*
+**Params and Response**: See *<a id="getPerpetualPositions" href="/developers/indexer/indexer_api#listpositions">Indexer API</a>*
 
 
 ### Get Orders
@@ -348,7 +348,7 @@ orders = orders_response.data
 </Tab>
 </Tabs>
 
-**Params and Response**: See *<a id="listOrders" href="/integration_docs/indexer_api#listorders">Indexer API</a>*
+**Params and Response**: See *<a id="listOrders" href="/developers/indexer/indexer_api#listorders">Indexer API</a>*
 
 
 ### Get Order
@@ -370,7 +370,7 @@ order = order_response.data
 </Tab>
 </Tabs>
 
-**Params and Response**: See *<a id="getOrder" href="/integration_docs/indexer_api#getorder">Indexer API</a>*
+**Params and Response**: See *<a id="getOrder" href="/developers/indexer/indexer_api#getorder">Indexer API</a>*
 
 
 ### Get Fills
@@ -392,7 +392,7 @@ fills = fills_response.data['fills']
 </Tab>
 </Tabs>
 
-**Params and Response**: See *<a id="getFills" href="/integration_docs/indexer_api#getfills">Indexer API</a>*
+**Params and Response**: See *<a id="getFills" href="/developers/indexer/indexer_api#getfills">Indexer API</a>*
 
 
 
@@ -415,7 +415,7 @@ transfers = transfers_response.data['transfers']
 </Tab>
 </Tabs>
 
-**Params and Response**: See *<a id="getTransfers" href="/integration_docs/indexer_api#gettransfers">Indexer API</a>*
+**Params and Response**: See *<a id="getTransfers" href="/developers/indexer/indexer_api#gettransfers">Indexer API</a>*
 
 
 ### Get Historical PNL
@@ -437,5 +437,5 @@ historical_pnl = historical_pnl_response.data['historicalPnl']
 </Tab>
 </Tabs>
 
-**Params and Response**: See *<a id="getFills" href="/integration_docs/indexer_api#gethistoricalpnl">Indexer API</a>*
+**Params and Response**: See *<a id="getFills" href="/developers/indexer/indexer_api#gethistoricalpnl">Indexer API</a>*
 


### PR DESCRIPTION
Indexer API docs moved from `Integration docs` to `Developer/Indexer` but the links in `Indexer Client` docs weren't updated.
A couple links were incorrect as well.