### PR TITLE
add bridge-daemon-eth-rpc-endpoint flag to dydxprotocold start commands

### DIFF
--- a/pages/validators/running_full_node.md
+++ b/pages/validators/running_full_node.md
@@ -17,7 +17,7 @@ Find the seed node's ID and the IP address from [Resources](../networks/network1
 
 For example,
 ```bash
-dydxprotocold start --p2p.seeds="..." --non-validating-full-node=true
+dydxprotocold start --p2p.seeds="..." --bridge-daemon-eth-rpc-endpoint="<eth rpc endpoint>" --non-validating-full-node=true
 ```
 
 💡**Note**: if you want to disable gRPC on your full node, it is important to start the node with the

--- a/pages/validators/upgrades/performing_upgrades.md
+++ b/pages/validators/upgrades/performing_upgrades.md
@@ -115,7 +115,7 @@ chmod 755 dydxprotocold
 4. Restart the application using the **new binary from step 1**.
 
 ```bash
-./dydxprotocold start --p2p.seeds="[seed_node_id]@[seed_node_ip_addr]:26656"
+./dydxprotocold start --p2p.seeds="[seed_node_id]@[seed_node_ip_addr]:26656" --bridge-daemon-eth-rpc-endpoint="<eth rpc endpoint>"
 ```
 
 #### Upgrading to a Patch Version (e.g. v0.0.2)
@@ -131,7 +131,7 @@ chmod 755 dydxprotocold
 4. Restart the application using the new binary from step 1.
 
 ```bash
-./dydxprotocold start --p2p.seeds="[seed_node_id]@[seed_node_ip_addr]:26656"
+./dydxprotocold start --p2p.seeds="[seed_node_id]@[seed_node_ip_addr]:26656" --bridge-daemon-eth-rpc-endpoint="<eth rpc endpoint>"
 ```
 
 ---
@@ -174,5 +174,5 @@ If you don’t have a data backup:
 3. Restart your node.
 
 ```bash
-./dydxprotocold start --p2p.seeds="[seed_node_id]@[seed_node_ip_addr]:26656"
+./dydxprotocold start --p2p.seeds="[seed_node_id]@[seed_node_ip_addr]:26656" --bridge-daemon-eth-rpc-endpoint="<eth rpc endpoint>"
 ```


### PR DESCRIPTION
node panics without `--bridge-daemon-eth-rpc-endpoint` specified