### PR TITLE
fixed typos on validator client documentation

### DIFF
--- a/pages/developers/clients/validator_client.mdx
+++ b/pages/developers/clients/validator_client.mdx
@@ -24,7 +24,7 @@ import { Tab, Tabs } from "nextra-theme-docs";
 <Tabs items={["TypeScript", "Python"]}>
   <Tab>
     ```typescript copy
-    import { ValidatorClient } from "@dydxprotocol/v4-client-js";
+    import { ValidatorClient, Network } from "@dydxprotocol/v4-client-js";
 
     const client = await ValidatorClient.connect(Network.testnet().validatorConfig);
     ```
@@ -47,7 +47,7 @@ import { Tab, Tabs } from "nextra-theme-docs";
           ValidatorClient,
           IndexerConfig,
           ValidatorConfig
-        } from '@dydxprotocol/v4-client-js-js';
+        } from '@dydxprotocol/v4-client-js';
 
         const indexerConfig = new IndexerConfig(
             {INDEXER_REST_URL},
@@ -310,8 +310,7 @@ import { Tab, Tabs } from "nextra-theme-docs";
 <Tabs items={["TypeScript", "Python"]}>
   <Tab>
     ```typescript copy
-    import { Order_Side, Order_TimeInForce } from '@dydxprotocol/dydxjs/src/codegen/dydxprotocol/clob/order';
-    import { OrderFlags, SubaccountClient } from '@dydxprotocol/v4-client-js';
+    import { OrderFlags, Order_Side, Order_TimeInForce, SubaccountClient } from '@dydxprotocol/v4-client-js';
 
     const subaccount = new SubaccountClient(wallet, 0);
     const clientId = 123 // set to a number, can be used by the client to identify the order


### PR DESCRIPTION
Fixed three typos on the validator client page:

**1. Added a missing import from one example**
Before:
![image](https://github.com/dydxprotocol/v4-documentation/assets/7104877/c71417c1-5931-4f0c-b2ed-d8d99d1c0593)
After:
![image](https://github.com/dydxprotocol/v4-documentation/assets/7104877/45ec79f7-3e5a-4879-9042-5d13c8f1954e)

**2. Fixed package typo:**
Before:
![image](https://github.com/dydxprotocol/v4-documentation/assets/7104877/0a3deb19-dc66-4923-8fd6-fadc948e475a)
After:
![image](https://github.com/dydxprotocol/v4-documentation/assets/7104877/057b4bef-be35-4566-a07d-428ead9af4d4)

**3. Removed a bad import from one example**
Before:
![image](https://github.com/dydxprotocol/v4-documentation/assets/7104877/2b143267-8d63-4466-94e3-fd43ae8f4b4b)
After:
![image](https://github.com/dydxprotocol/v4-documentation/assets/7104877/4faf37cd-42f5-423f-b9d2-4d0df15d3651)
