### PR TITLE
Add note on relative freshness of indexer rest vs ws data

### DIFF
--- a/pages/developers/indexer/indexer_api.mdx
+++ b/pages/developers/indexer/indexer_api.mdx
@@ -1,4 +1,3 @@
-
 # Indexer API v1.0.0
 
 > Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
@@ -6,6 +5,8 @@
 Base URLs:
 
 * <a href="https://dydx-testnet.imperator.co/v4">https://dydx-testnet.imperator.co/v4</a>
+
+Note: Messages on Indexer WebSocket feeds are typically more recent than data fetched via Indexer's REST API, because the latter is backed by read replicas of the databases that feed the former. Ordinarily this difference is minimal (less than a second), but it might become prolonged under load. Please see [Indexer Architecture](https://dydx.exchange/blog/v4-deep-dive-indexer) for more information.
 
 # Authentication
 

--- a/pages/developers/indexer/indexer_websocket.md
+++ b/pages/developers/indexer/indexer_websocket.md
@@ -4,6 +4,8 @@ dYdX offers a WebSocket API for streaming v4 updates.
 
 You can connect to the v4 Testnet's webSockets at: `wss://indexer.v4testnet.dydx.exchange/v4/ws`
 
+Note: Messages on Indexer WebSocket feeds are typically more recent than data fetched via Indexer's REST API, because the latter is backed by read replicas of the databases that feed the former. Ordinarily this difference is minimal (less than a second), but it might become prolonged under load. Please see [Indexer Architecture](https://dydx.exchange/blog/v4-deep-dive-indexer) for more information.
+
 ## Overall
 
 ### Connect


### PR DESCRIPTION
Adding a clarifying note per this per [slack convo](https://dydx-team.slack.com/archives/C03GKH23YAZ/p1707875034580629?thread_ts=1707845388.162029&cid=C03GKH23YAZ), because this matters for API users. 