### PR TITLE
Update Resources page

### DIFF
--- a/pages/network/resources.md
+++ b/pages/network/resources.md
@@ -10,7 +10,6 @@ For **the deployment by DYDX token holders**, use the below:
 | Bware Labs    | `f04a77b92d0d86725cdb2d6b7a7eb0eda8c27089@dydx-mainnet-seed.bwarelabs.com:36656`       |
 | Lavender.Five | `20e1000e88125698264454a884812746c2eb4807@seeds.lavenderfive.com:23856`                |
 | CryptoCrew    | `c2c2fcb5e6e4755e06b83b499aff93e97282f8e8@tenderseed.ccvalidators.com:26401`           |
-| Crosnest      | `4f20c3e303c9515051b6276aeb89c0b88ee79f8f@seed.dydx.cros-nest.com:26656`               |
 | DSRV          | `a9cae4047d5c34772442322b10ef5600d8e54900@dydx-mainnet-seednode.allthatnode.com:26656` |
 | Luganodes     | `802607c6db8148b0c68c8a9ec1a86fd3ba606af6@64.227.38.88:26656`                          |
 | AutoStake     | `ebc272824924ea1a27ea3183dd0b9ba713494f83@dydx-mainnet-seed.autostake.com:27366`       |
@@ -47,7 +46,6 @@ For **the deployment by DYDX token holders**, use the below:
 | KingNodes     | `f94dcfbccb9019584d1790562a020507b050d9ba@51.77.56.23:23856` <br> `6bc1068d9a257931083ddc75ad3b1003a46e5b0d@15.235.160.127:23856`                                                                                                                                                                                                                 | `EU_West` <br> `Asia_SE`                                                |
 | Polkachu      | `580ec248de1f41d4e50abe132b7838348db55b80@176.9.144.40:23856` <br> `90b0ee8e73d8237b06356b244ff9854d1991a1f8@65.109.115.228:23856` <br> `874b5ab53d8f5edae6674ad394f20e2b297cf73f@199.254.199.182:23856` <br> `e3aa07f6f97fcccdf57b64aa5f4f11761df3852a@15.235.160.15:23856` <br> `a879fe2926c2b8f0d86e8e973210c30b8634abb4@15.235.204.159:23856` | `Germany` <br> `Finland` <br> `Japan` <br> `Singapore` <br> `Singapore` |
 | Bware Labs    | `b0137ca9fec8d2990d804e20bc5b74e641bb45e8@dydx-mainnet-statesync-rpc.bwarelabs.com:443`                                                                                                                                                                                                                                                           | `Germany`                                                               |
-| Lavender.Five |                                                                                                                                                                                                                                                                                                                                                   |                                                                         |
 | AutoStake     | `ebc272824924ea1a27ea3183dd0b9ba713494f83@dydx-mainnet-peer.autostake.com:27366`                                                                                                                                                                                                                                                                  | `EU,Poland`                                                             |
 
 For **Testnet**, use the below:
@@ -83,7 +81,6 @@ For **Testnet**, use the below:
 | AutoStake     | `https://dydx-mainnet-rpc.autostake.com:443`           | 4 req/s    |
 | EcoStake      | `https://rpc-dydx.ecostake.com:443`                    |            |
 | PublicNode    | `https://dydx-rpc.publicnode.com:443`                  |            |
-| Cros-Nest     | `https://rpc-dydx.cros-nest.com:443`                   |            |
 | Enigma        | `https://dydx-rpc.enigma-validator.com:443`            |            |
 | CosmosSpaces  | `https://rpc-dydx.cosmos-spaces.cloud:443`             |            |
 
@@ -97,7 +94,6 @@ For **Testnet**, use the below:
 | AutoStake     | `https://dydx-mainnet-lcd.autostake.com:443`           | 4 req/s    |
 | EcoStake      | `https://rest-dydx.ecostake.com:443`                   |            |
 | PublicNode    | `https://dydx-rest.publicnode.com:443`                 |            |
-| Cros-Nest     | `https://rest-dydx.cros-nest.com:443`                  |            |
 | Enigma        | `https://dydx-lcd.enigma-validator.com:443`            |            |
 | CosmosSpaces  | `https://api-dydx.cosmos-spaces.cloud:443`             |            |
 
@@ -111,7 +107,6 @@ For **Testnet**, use the below:
 | AutoStake     | `https://dydx-mainnet-grpc.autostake.com:443`                                                                                                                                                                                                   | 4 req/s    |
 | EcoStake      | `https://grpc-dydx.ecostake.com:443`                                                                                                                                                                                                            |            |
 | PublicNode    | `https://dydx-grpc.publicnode.com:443`                                                                                                                                                                                                          |            |
-| Cros-Nest     | `https://grpc-dydx.cros-nest.com:443`                                                                                                                                                                                                           |            |
 | CosmosSpaces  | `http://grpc-dydx.cosmos-spaces.cloud:4990`                                                                                                                                                                                                     |            |
 
 ### RPC (For Testnet)
@@ -186,6 +181,7 @@ For **the deployment by DYDX token holders**, use the below:
 | Keplr                       | `https://wallet.keplr.app/chains/dydx`                                                                 |
 | Validator Metrics           | `https://p.ap1.datadoghq.com/sb/610e1836-51dd-11ee-a995-da7ad0900009-78607847ff8632d8a96737ed3437f40c` |
 | #validators Discord Channel | `https://discord.com/channels/724804754382782534/1029585380170805379`                                  |
+| FE Bug Report Form          | `https://www.dydxopsdao.com/feedback`                                                                  |
 
 For **Testnet**, use the below:
 


### PR DESCRIPTION
The dYdX Ops subDAO suggest that the dYdX Chain Software documentation adjusts the Resources page with the following changes:
* add dYdX Ops Frontend Bug Report link
* remove Lavender.Five's empty row from StateSync nodes
* remove cros-nest resources - they now err with 522