### PR TITLE
Update rewards_fees_and_parameters.md

### DIFF
--- a/pages/getting_started/rewards_fees_and_parameters.md
+++ b/pages/getting_started/rewards_fees_and_parameters.md
@@ -122,7 +122,7 @@ These parameters define how staking works on the protocol and norms around staki
 
 |                  | BondDenom | MaxValidators | MinCommissionRate | Unbonding Time |                          
 |------------------|-------- |------------|---------------|---------------|
-| Slashing Params  | Decided at Genesis, by validators | 60  | 5%         | 30 days | 
+| Staking Params  | Decided at Genesis, by validators | 60  | 5%         | 30 days | 
 
 _MaxValidators_: Every block, the top MaxValidators validators by stake weight are included in the active validator set.
 


### PR DESCRIPTION
Fix typo in dydx docs, "Getting Started" → "Rewards, Fees and Parameters" page. The table under "Staking Parameters" refers to "Slashing Params" instead of "Staking Params".