### PR TITLE
Remove stale endpoints

### DIFF
--- a/pages/network/resources.mdx
+++ b/pages/network/resources.mdx
@@ -190,7 +190,6 @@ For **the deployment by DYDX token holders**:
 | Bware Labs | `https://dydx-mainnet-full-grpc.public.blastapi.io:443` | 20 req/s |
 | KingNodes | `https://dydx-ops-grpc.kingnodes.com:443` | 250 req/m |
 | Lavender.Five | `https://dydx-grpc.lavenderfive.com:443` | |
-| AutoStake | `https://dydx-mainnet-grpc.autostake.com:443` | 4 req/s |
 | PublicNode | `https://dydx-grpc.publicnode.com:443` | |
 </Tab>
 </Tabs>


### PR DESCRIPTION
Remove Autostake gRPC endpoint:
```
grpcurl dydx-mainnet-grpc.autostake.com:443 list

Failed to list services: rpc error: code = PermissionDenied desc = unexpected HTTP status code received from server: 403 (Forbidden); transport: received unexpected content-type "text/html"
```