### PR TITLE
Updated "creating Local wallet" in composite_client.mdx

### DIFF
--- a/pages/api_integration-clients/composite_client.mdx
+++ b/pages/api_integration-clients/composite_client.mdx
@@ -111,7 +111,8 @@ and call ValidatorClient with the correct quantums and subticks for you.
   </Tab>
   <Tab>
     ```python copy
-    from v4_client_py.chain.aerial.wallet import LocalWallet, BECH32_PREFIX
+    from v4_client_py.chain.aerial.wallet import LocalWallet
+    from v4_client_py.clients.constants import BECH32_PREFIX
     mnemonic = 'YOUR MNEMONIC HERE'
     wallet = LocalWallet.from_mnemonic(DYDX_TEST_MNEMONIC, BECH32_PREFIX)
     ```


### PR DESCRIPTION
BECH32_PREFIX lies in v4_client_py.clients.constants and not in v4_client_py.chain.aerial.wallet