### PR TITLE
Rename dYdX Chain documentation for Google search

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -1,4 +1,4 @@
-# Introduction
+# dYdX Chain Documentation
 
 Welcome to the dYdX Chain documentation! This is the source of truth for information about dYdX Chain.
 


### PR DESCRIPTION
Make this not say "Introduction" anymore

![image](https://github.com/user-attachments/assets/7123355f-f93a-400e-91f8-605bc895e157)
