### PR TITLE
Fix broken links on socket_client.mdx

### DIFF
--- a/pages/api_integration-clients/socket_client.mdx
+++ b/pages/api_integration-clients/socket_client.mdx
@@ -130,7 +130,7 @@ ws.unsubscribe_from_markets()
 </Tab>
 </Tabs>
 
-**Response and Channel Data**: See *<a id="socket" href="/integration_docs/indexer_websocket">Indexer Socket</a>* for *<a id="marketsResponse" href="/integration_docs/indexer_websocket#initial-response-3">Initial Response</a>* and *<a id="marketsChannelData" href="/integration_docs/indexer_websocket#channel-data-3">Channel Update</a>*
+**Response and Channel Data**: See *<a id="socket" href="/api_integration-indexer/indexer_websocket">Indexer Socket</a>* for *<a id="marketsResponse" href="/api_integration-indexer/indexer_websocket#initial-response-3">Initial Response</a>* and *<a id="marketsChannelData" href="/api_integration-indexer/indexer_websocket#channel-data-3">Channel Update</a>*
 
 ### Trades Channel
 
@@ -157,7 +157,7 @@ ws.unsubscribe_from_trades(ticker)
 </Tab>
 </Tabs>
 
-**Response and Channel Data**: See *<a id="socket" href="/integration_docs/indexer_websocket">Indexer Socket</a>* for *<a id="tradesResponse" href="/integration_docs/indexer_websocket#initial-response-2">Initial Response</a>* and *<a id="tradesChannelData" href="/integration_docs/indexer_websocket#channel-data-2">Channel Update</a>*
+**Response and Channel Data**: See *<a id="socket" href="/api_integration-indexer/indexer_websocket">Indexer Socket</a>* for *<a id="tradesResponse" href="/api_integration-indexer/indexer_websocket#initial-response-2">Initial Response</a>* and *<a id="tradesChannelData" href="/api_integration-indexer/indexer_websocket#channel-data-2">Channel Update</a>*
 
 
 ### Orderbook Channel
@@ -185,7 +185,7 @@ ws.unsubscribe_from_orderbook(ticker)
 </Tab>
 </Tabs>
 
-**Response and Channel Data**: See *<a id="socket" href="/integration_docs/indexer_websocket">Indexer Socket</a>* for *<a id="tradesResponse" href="/integration_docs/indexer_websocket#initial-response-1">Initial Response</a>* and *<a id="tradesChannelData" href="/integration_docs/indexer_websocket#channel-data-1">Channel Update</a>*
+**Response and Channel Data**: See *<a id="socket" href="/api_integration-indexer/indexer_websocket">Indexer Socket</a>* for *<a id="tradesResponse" href="/api_integration-indexer/indexer_websocket#initial-response-1">Initial Response</a>* and *<a id="tradesChannelData" href="/api_integration-indexer/indexer_websocket#channel-data-1">Channel Update</a>*
 
 
 ### Candles Channel
@@ -213,7 +213,7 @@ ws.unsubscribe_from_candles(ticker, resolution)
 </Tab>
 </Tabs>
 
-**Response and Channel Data**: See *<a id="socket" href="/integration_docs/indexer_websocket">Indexer Socket</a>* for *<a id="tradesResponse" href="/integration_docs/indexer_websocket#initial-response-4">Initial Response</a>* and *<a id="tradesChannelData" href="/integration_docs/indexer_websocket#channel-data-4">Channel Update</a>*
+**Response and Channel Data**: See *<a id="socket" href="/api_integration-indexer/indexer_websocket">Indexer Socket</a>* for *<a id="tradesResponse" href="/api_integration-indexer/indexer_websocket#initial-response-4">Initial Response</a>* and *<a id="tradesChannelData" href="/api_integration-indexer/indexer_websocket#channel-data-4">Channel Update</a>*
 
 ### Subaccount Channel
 
@@ -241,4 +241,4 @@ ws.unsubscribe_from_subaccount(ticker, resolution)
 </Tab>
 </Tabs>
 
-**Response and Channel Data**: See *<a id="socket" href="/integration_docs/indexer_websocket">Indexer Socket</a>* for *<a id="tradesResponse" href="/integration_docs/indexer_websocket#initial-response">Initial Response</a>* and *<a id="tradesChannelData" href="/integration_docs/indexer_websocket#channel-data">Channel Update</a>*
+**Response and Channel Data**: See *<a id="socket" href="/api_integration-indexer/indexer_websocket">Indexer Socket</a>* for *<a id="tradesResponse" href="/api_integration-indexer/indexer_websocket#initial-response">Initial Response</a>* and *<a id="tradesChannelData" href="/api_integration-indexer/indexer_websocket#channel-data">Channel Update</a>*


### PR DESCRIPTION
Fix broken links by replacing `https://docs.dydx.exchange/integration_docs/indexer_websocket` for `https://docs.dydx.exchange/api_integration-indexer/indexer_websocket`