### PR TITLE
Update seed node for Bwarelabs

### DIFF
--- a/pages/infrastructure_providers-network/resources.mdx
+++ b/pages/infrastructure_providers-network/resources.mdx
@@ -64,7 +64,7 @@ For **the deployment by DYDX token holders**:
 | ------------- | -------------------------------------------------------------------------------------- |
 | Polkachu      | `ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@seeds.polkachu.com:23856`                    |
 | KingNodes     | `65b740ee326c9260c30af1f044e9cda63c73f7c1@seeds.kingnodes.net:23856`                   |
-| Bware Labs    | `f04a77b92d0d86725cdb2d6b7a7eb0eda8c27089@dydx-mainnet-seed.bwarelabs.com:36656`       |
+| Bware Labs    | `d8e106274b24ec64ce724a611def6a3637226745@dydx-mainnet-seed.bwarelabs.com:36656`       |
 | Lavender.Five | `20e1000e88125698264454a884812746c2eb4807@seeds.lavenderfive.com:23856`                |
 | CryptoCrew    | `c2c2fcb5e6e4755e06b83b499aff93e97282f8e8@tenderseed.ccvalidators.com:26401`           |
 | DSRV          | `a9cae4047d5c34772442322b10ef5600d8e54900@dydx-mainnet-seednode.allthatnode.com:26656` |

--- a/pages/infrastructure_providers-validators/set_up_full_node.md
+++ b/pages/infrastructure_providers-validators/set_up_full_node.md
@@ -116,7 +116,7 @@ A seed node acts as an address book and helps your node join the network. To upd
 # Example for DYDX token holders on mainnet
 SEED_NODES=("ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@seeds.polkachu.com:23856", 
 "65b740ee326c9260c30af1f044e9cda63c73f7c1@seeds.kingnodes.net:23856", 
-"f04a77b92d0d86725cdb2d6b7a7eb0eda8c27089@dydx-mainnet-seed.bwarelabs.com:36656",
+"d8e106274b24ec64ce724a611def6a3637226745@dydx-mainnet-seed.bwarelabs.com:36656",
 "20e1000e88125698264454a884812746c2eb4807@seeds.lavenderfive.com:23856",
 "c2c2fcb5e6e4755e06b83b499aff93e97282f8e8@tenderseed.ccvalidators.com:26401",
 "a9cae4047d5c34772442322b10ef5600d8e54900@dydx-mainnet-seednode.allthatnode.com:26656",


### PR DESCRIPTION
Bwarelabs migrated the dydx mainnet seed node. This PR reflects this change in the docs.