### PR TITLE
docs: fix Python signatures for indexer websocket orders/trades

### DIFF
--- a/docs/pages/indexer-client/websockets/orders.mdx
+++ b/docs/pages/indexer-client/websockets/orders.mdx
@@ -10,8 +10,8 @@ Data feed of the orders of a market. Data contains lists of the bids and asks of
 
 ```python [Python]
 # class `OrderBook`
-def subscribe(self, market: str, batched: bool = True) -> Self
-def unsubscribe(self, market: str)
+def subscribe(self, id: str, batched: bool = True) -> Self
+def unsubscribe(self, id: str)
 ```
 
 ```typescript [TypeScript]

--- a/docs/pages/indexer-client/websockets/trades.mdx
+++ b/docs/pages/indexer-client/websockets/trades.mdx
@@ -10,8 +10,8 @@ Data feed of the trades on a market. Data contains order fills updates, such as 
 
 ```python [Python]
 # class `Trades`
-def subscribe(self, market: str, batched: bool = True) -> Self
-def unsubscribe(self, market: str)
+def subscribe(self, id: str, batched: bool = True) -> Self
+def unsubscribe(self, id: str)
 ```
 
 ```typescript [TypeScript]
@@ -31,7 +31,7 @@ pub async fn trades(
 ```
 
 ```url [Channel]
-v4_orderbook
+v4_trades
 ```
 
 :::


### PR DESCRIPTION
## Summary
- Correct the Python `OrderBook.subscribe`/`unsubscribe` signatures on the Orders websocket page 
- Fix the Trades channel name which was incorrectly listed as `v4_orderbook`; the actual channel is `v4_trades` 
