### PR TITLE
update mainnet seed nodes

### DIFF
--- a/docs/pages/nodes/resources.mdx
+++ b/docs/pages/nodes/resources.mdx
@@ -70,11 +70,7 @@ testnet: https://github.com/dydxprotocol/v4-testnets/tree/main/dydx-testnet-4
 | Polkachu      | `ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@seeds.polkachu.com:23856`                    |
 | KingNodes     | `df1f145848d253800d4e4216e8793158688912f1@seeds.kingnodes.com:23856`                   |
 | Enigma        | `6a720a1e5e8be9acf2752b22dc868ea2f95aaaf7@dydx-seeds.enigma-validator.com:1490`        |
-| Lavender.Five | `20e1000e88125698264454a884812746c2eb4807@seeds.lavenderfive.com:23856`                |
 | CryptoCrew    | `c2c2fcb5e6e4755e06b83b499aff93e97282f8e8@tenderseed.ccvalidators.com:26401`           |
-| DSRV          | `a9cae4047d5c34772442322b10ef5600d8e54900@dydx-mainnet-seednode.allthatnode.com:26656` |
-| Luganodes     | `802607c6db8148b0c68c8a9ec1a86fd3ba606af6@64.227.38.88:26656`                          |
-| AutoStake     | `ebc272824924ea1a27ea3183dd0b9ba713494f83@dydx-mainnet-seed.autostake.com:27366`       |
 
 :::
 

--- a/docs/pages/nodes/running-node/setup.mdx
+++ b/docs/pages/nodes/running-node/setup.mdx
@@ -123,12 +123,8 @@ Check the [Resources](/nodes/resources#seed-nodes) page for an up-to-date list o
 # Example for DYDX token holders on mainnet
 SEED_NODES=("ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@seeds.polkachu.com:23856", 
 "df1f145848d253800d4e4216e8793158688912f1@seeds.kingnodes.com:23856", 
-"d8e106274b24ec64ce724a611def6a3637226745@dydx-mainnet-seed.bwarelabs.com:36656",
-"20e1000e88125698264454a884812746c2eb4807@seeds.lavenderfive.com:23856",
-"c2c2fcb5e6e4755e06b83b499aff93e97282f8e8@tenderseed.ccvalidators.com:26401",
-"a9cae4047d5c34772442322b10ef5600d8e54900@dydx-mainnet-seednode.allthatnode.com:26656",
-"802607c6db8148b0c68c8a9ec1a86fd3ba606af6@64.227.38.88:26656",
-"ebc272824924ea1a27ea3183dd0b9ba713494f83@dydx-mainnet-seed.autostake.com:27366"
+"6a720a1e5e8be9acf2752b22dc868ea2f95aaaf7@dydx-seeds.enigma-validator.com:1490",
+"c2c2fcb5e6e4755e06b83b499aff93e97282f8e8@tenderseed.ccvalidators.com:26401"
 )
 
 sed -i 's/seeds = ""/seeds = "'"${SEED_NODES[*]}"'"/' $HOME/.dydxprotocol/config/config.toml


### PR DESCRIPTION
Seed node liveness can be verified using [dydx-seed-checker](https://github.com/dydxopsdao/dydx-seed-checker) 

Note: Enigma's node is currently unreachable but they are funded by dYdX Grants and we are working with them to get their seed node live again.