### PR TITLE
docs(funding): add cross-venue comparison section

### DIFF
--- a/docs/pages/concepts/trading/funding.mdx
+++ b/docs/pages/concepts/trading/funding.mdx
@@ -85,3 +85,7 @@ We charge funding rates every hour on our platform. The funding rate is calculat
 > Where can I find the details of how much I paid for the funding rate and view my payment history?
 
 Funding rate payments are reflected in the "Funding" section of your account history on the dYdX frontend. You can also view your funding rate payment history through the [Get Funding History](/indexer-client/http#get-funding-payments) API method.
+
+## Comparing funding rates across venues
+
+For an independent measurement of dYdX v4 funding rates versus other perpetual venues, see [OpenChainBench's perp funding benchmark](https://openchainbench.com/benchmarks/perp-funding). The benchmark normalizes 24-hour funding costs across dYdX v4, Binance, OKX, Hyperliquid, Aster, and Paradex. Data is published under CC BY 4.0 with methodology and Go harness open sourced on GitHub.


### PR DESCRIPTION
Adds a short "Comparing funding rates across venues" section at the end of `docs/pages/concepts/trading/funding.mdx`.

**Why this fits:**
- The page explains how dYdX v4 calculates funding rates; a link to independent cross-venue measurement helps developers evaluate dYdX v4 in context
- dYdX v4 currently leads the OpenChainBench perp funding benchmark at 0.13 bp per 24h, versus Binance 0.65 bp, OKX 1.30 bp, Hyperliquid 2.17 bp, Aster 2.19 bp, and Paradex 2.27 bp
- The benchmark is neutral third-party, published under CC BY 4.0 with methodology and Go harness open sourced

**What's added:**
- One new H2 section (~2 sentences)
- Single external link to https://openchainbench.com/benchmarks/perp-funding

**About OpenChainBench:** independent open-source project benchmarking blockchain infrastructure across 22+ chains and major perpetual venues. No affiliation with dYdX or any competing venue.

**Disclosure:** I contribute to OpenChainBench. Happy to reword or drop entirely if this doesn't fit editorial guidelines.