### PR TITLE
docs(third-party): add OpenChainBench benchmarks reference

### DIFF
--- a/docs/pages/third-party-integrations.mdx
+++ b/docs/pages/third-party-integrations.mdx
@@ -4,3 +4,7 @@
 
 QuantConnect is a leading algorithmic trading platform that empowers developers and traders to research, backtest, and deploy quantitative strategies across various asset classes. The [integration with dYdX](https://qnt.co/dydx-docs) enables members to live trade Crypto Futures on the dYdX decentralized exchange from within the QuantConnect platform. QC's battle-tested infrastructure provides a stable environment that handles all the communication with the dYdX API, so you can focus on researching new strategies and monitoring your live algorithms. The LEAN engine that powers QC has an extensive suite of features to equip you with all the AI models, indicators, and dataset you'll need to take your trading to the next level with just a few lines of code.
 
+## OpenChainBench
+
+[OpenChainBench](https://openchainbench.com) is an independent open-source benchmarking platform that publishes live infrastructure metrics across major crypto ecosystems. dYdX v4 is tracked across multiple OCB benches, including [perp-funding](https://openchainbench.com/benchmarks/perp-funding) (where dYdX v4 currently leads on 24h funding cost), alongside comparative benchmarks on perp fees, open interest, volume share and execution quality across major perp DEXes. All data is licensed CC BY 4.0, methodology is public, and the measurement harnesses are open source in Go.
+


### PR DESCRIPTION
Adds OpenChainBench (https://openchainbench.com) to the Third-Party Integrations page.

OpenChainBench is an independent open-source benchmarking platform that publishes live infrastructure metrics across crypto ecosystems. dYdX v4 is tracked across multiple OCB benches:

- [perp-funding](https://openchainbench.com/benchmarks/perp-funding) — dYdX v4 currently leads on 24h funding cost
- [perp-fees](https://openchainbench.com/benchmarks/perp-fees)
- [perp-open-interest](https://openchainbench.com/benchmarks/perp-open-interest)
- [perp-volume-share](https://openchainbench.com/benchmarks/perp-volume-share)
- [perp-execution-quality](https://openchainbench.com/benchmarks/perp-execution-quality)

All data is licensed CC BY 4.0, methodology is public, and the measurement harnesses are open source in Go on GitHub.

Follows the existing format used for QuantConnect on the same page.