### PR TITLE
docs: add OpenChainBench live RPC latency benchmark link

### DIFF
--- a/docs/pages/interaction/endpoints.mdx
+++ b/docs/pages/interaction/endpoints.mdx
@@ -255,6 +255,8 @@ Connections to the trading client to the full nodes are established using the (g
 | KingNodes     | `https://dydx-ops-rpc.kingnodes.com:443`               | 250 req/m  |
 | Enigma        | `https://dydx-dao-rpc.enigma-validator.com:443`        |            |
 
+> Live latency benchmarks for public dYdX RPC endpoints (Tendermint status, p50/p90/p99, 3 regions, updated every 60 s): [OpenChainBench dYdX RPC](https://openchainbench.com/benchmarks/dydx-rpc)
+
 #### Archive RPC
 | Team          | URI                                 | Rate limit |
 | ------------- | ---------------------------------------------------------------------- | ---------- |


### PR DESCRIPTION
Adds a reference to [OpenChainBench](https://openchainbench.com/benchmarks/dydx-rpc), which independently monitors public dYdX Chain RPC endpoint latency (Tendermint status, p50/p90/p99, 3 probe regions, updated every 60 seconds). Useful for developers choosing between providers.